### PR TITLE
Queries are now validated when user presses submit button

### DIFF
--- a/src/pages/Validator/Validator.js
+++ b/src/pages/Validator/Validator.js
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useState, useEffect } from "react";
 import "./Validator.scss";
 import ValidatorForm from "./ValidatorForm";
 import TokenBar from "./TokenBar";
@@ -41,10 +41,15 @@ export default function Validator(props) {
   let deleteCurrentQuery = () => {
     let updatedQueries = [...queries];
     updatedQueries.splice(selectedIndex, 1);
-    if (queries.length < 3) fetchMoreQueries(3);
+
+    // If we have fallen below 2 queries remaining, fetch 3 more.
+    if (updatedQueries.length < 2)
+      fetchMoreQueries(3, updatedQueries);
+    else
+      setQueries(updatedQueries);
+
     if (selectedIndex >= updatedQueries.length)
       setSelectedIndex(updatedQueries.length - 1);
-    setQueries(updatedQueries);
   };
 
   let getNextQuery = (submittedQuery) => {
@@ -52,18 +57,20 @@ export default function Validator(props) {
     let updatedQueries = [...queries];
     submittedQuery.validated = true;
     updatedQueries[selectedIndex] = submittedQuery;
-    setQueries(updatedQueries);
 
-    if (queries.length - 2 <= selectedIndex) fetchMoreQueries(1);
+    if (updatedQueries.length - 2 <= selectedIndex)
+      fetchMoreQueries(1, updatedQueries);
+    else
+      setQueries(updatedQueries);
 
     //Shift to next query
     setSelectedIndex((i) => i + 1);
   };
 
-  let fetchMoreQueries = (count) => {
+  let fetchMoreQueries = (count, currentQueries) => {
     console.log("fetching");
-    let dequeueCount = Math.max(count + queries.length - maxQueryQueueSize, 0);
-    let updatedQueries = queries.slice(dequeueCount);
+    let dequeueCount = Math.max(count + currentQueries.length - maxQueryQueueSize, 0);
+    let updatedQueries = currentQueries.slice(dequeueCount);
     //Actually fetch the queries here This is for testing purposes
     let response = new Array(count).fill({
       question: "This is from the {server}",

--- a/src/pages/Validator/Validator.js
+++ b/src/pages/Validator/Validator.js
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from "react";
+import React, { useState } from "react";
 import "./Validator.scss";
 import ValidatorForm from "./ValidatorForm";
 import TokenBar from "./TokenBar";


### PR DESCRIPTION
This was tricky! Previously, the 'submit' button was not actually setting the selected query's `validated` attribute to `true`. After digging around and reading up on `useState()` on [stackoverflow](https://stackoverflow.com/questions/33613728/what-happens-when-using-this-setstate-multiple-times-in-react-component), I learned that:

> "The set...() method does not immediately update the state of the component, it just puts the update in a queue to be processed later. React may batch multiple update requests together to make rendering more efficient. Due to this, special precautions must be made when you try to update the state based on the component's previous state."

We were trying to use `fetchMoreQueries()` in `getNextQuery()` and `deleteCurrentQuery()` based on changes we made to the `Validator`'s state within those functions using `setQueries()`. However, React doesn't update the queries right away, so `fetchMoreQueries()` was using a stale version of state, and then overwriting our updated queries with that stale version (because `fetchMoreQueries()` calls `setQueries()` too).

There are ways to fix this using `useEffect()`, but it seemed simpler to just pass the updated version of our queries to `fetchMoreQueries()` instead of basing it on the `Validator`'s current state.

Bonus: now the code only calls `setQueries()` once every time `getNextQuery()` and `deleteCurrentQuery()` are called, so we only re-render once (I think 🧐).

For the future: as it stands right now, it is impossible for the user to validate all the queries (and thus it is impossible for the `<AllValidated />` page to be rendered). When we hit the cap of 10 queries, a new query is fetched each time we submit. When we try to delete all the queries, the query bar repopulates with 3 new queries if we fall below 2 queries. Maybe this isn't actually an issue, but it's worth noting.

Open to thoughts and potential changes! 😋