### PR TITLE
Token suggestions based on entity synonyms

### DIFF
--- a/src/pages/Validator/AutocompleteList.js
+++ b/src/pages/Validator/AutocompleteList.js
@@ -1,32 +1,42 @@
 import React from "react";
 
 export default function AutocompleteList({
-  options = [],
+  entities = {},
   inputVal,
   onSelect,
   onCreate,
 }) {
-  let handleSelect = (i) => {
-    onSelect(options[i]);
+  // Calls onSelect to insert token into the UI
+  let handleSelect = (entity) => {
+    onSelect(entity);
   };
 
-  let shownOptions = options
-    .filter((option) => option.toLowerCase().startsWith(inputVal.toLowerCase()))
-    .map((option, i) => (
-      <li key={option} onClick={handleSelect.bind(this, i)}>
-        {option}
-      </li>
-    ));
+  let entitiesSeen = [];
 
+  // Create a list of synonyms, filter them with the input value, and then return a token if the entity isn't already displayed
+  let shownOptions = Object.keys(entities)
+    .filter((entity) => entity.toUpperCase().startsWith(inputVal.toUpperCase()))
+    .map((entity) => {
+      if (!entitiesSeen.includes(entities[entity])) {
+        entitiesSeen.push(entities[entity])
+        return (
+          <li key={entity} onClick={handleSelect.bind(this, entities[entity])} >
+            {entities[entity]}
+          </li >
+        )
+      }
+    });
+
+  // Render the list of tokens, if not display an add token button
   return (
     <ul className="AutocompleteList">
       {shownOptions.length ? (
         shownOptions
       ) : (
-        <li className="add-token" onClick={() => onCreate(inputVal)}>
-          Add Token
-        </li>
-      )}
+          <li className="add-token" onClick={() => onCreate(inputVal)}>
+            Add Token
+          </li>
+        )}
     </ul>
   );
 }

--- a/src/pages/Validator/ValidatorField.js
+++ b/src/pages/Validator/ValidatorField.js
@@ -119,7 +119,7 @@ export default class ValidatorField extends Component {
         />
         {this.state.showAutocomplete && (
           <AutocompleteList
-            options={this.props.autocompleteOptions}
+            entities={this.props.entityMatchingDict}
             inputVal={this.state.tokenVal}
             onSelect={this.autocompleteVal.bind(this)}
             onCreate={this.createToken.bind(this)}

--- a/src/pages/Validator/ValidatorForm.js
+++ b/src/pages/Validator/ValidatorForm.js
@@ -22,7 +22,7 @@ export default function ValidatorForm({ query, onDelete, onSubmit }) {
   /** Fetch autcomplete information for tokens */
   let fetchAutoComplete = async () => {
     let { data } = await axios.get('/entity_structure');
-    setautoCompleteOptions(Object.keys(data));
+    setautoCompleteOptions(Object.keys(data).map(s => s.toUpperCase()));
     buildEntityMatchingDict(data);
   };
   useEffect(fetchAutoComplete, []);

--- a/src/pages/Validator/ValidatorForm.js
+++ b/src/pages/Validator/ValidatorForm.js
@@ -2,6 +2,8 @@ import React, { useState, useEffect, useCallback } from "react";
 import ValidatorField from "./ValidatorField";
 import ValidatorToggle from "./ValidatorToggle";
 import ValidatorSelector from "./ValidatorSelector";
+import axios from 'axios';
+
 export default function ValidatorForm({ query, onDelete, onSubmit }) {
   let [question, setQuestion] = useState(query.question);
   let [answer, setAnswer] = useState(query.answer);
@@ -9,14 +11,7 @@ export default function ValidatorForm({ query, onDelete, onSubmit }) {
     query.isAnswerable ? "Yes" : "No"
   );
   //TODO: Make this React controlled state when we actually fetch
-  let autocompleteOptions = [
-    "Professor",
-    "Major",
-    "Minor",
-    "Concentration",
-    "Location",
-    "Email",
-  ];
+  let [autoCompleteOptions, setautoCompleteOptions] = useState(null);
   let [questionType, setQuestionType] = useState(query.type);
   let [selectorOptions] = useState([
     { title: "Fact", value: "fact" },
@@ -24,6 +19,13 @@ export default function ValidatorForm({ query, onDelete, onSubmit }) {
     { title: "Statistics", value: "statistics" },
     { title: "Other", value: "other" },
   ]);
+  let fetchAutoComplete = async () => {
+    let {data} = await axios.get('/entity_structure');
+    setautoCompleteOptions(Object.keys(data));
+    console.log(data)
+  };
+  useEffect(fetchAutoComplete, []);
+
   /** When Query changes, update the internal state of the form */
   let updateQueryState = () => {
     setQuestion(query.question);
@@ -65,14 +67,14 @@ export default function ValidatorForm({ query, onDelete, onSubmit }) {
         value={query.question}
         onChange={setQuestion}
         queryId={query.id}
-        autocompleteOptions={autocompleteOptions}
+        autocompleteOptions={autoCompleteOptions}
       />
       <ValidatorField
         title="Answer"
         value={query.answer}
         onChange={setAnswer}
         queryId={query.id}
-        autocompleteOptions={autocompleteOptions}
+        autocompleteOptions={autoCompleteOptions}
       />
       <div className="query-properties">
         <ValidatorToggle

--- a/src/pages/Validator/ValidatorForm.js
+++ b/src/pages/Validator/ValidatorForm.js
@@ -10,8 +10,8 @@ export default function ValidatorForm({ query, onDelete, onSubmit }) {
   let [isAnswerable, setAnswerable] = useState(
     query.isAnswerable ? "Yes" : "No"
   );
-  //TODO: Make this React controlled state when we actually fetch
   let [autoCompleteOptions, setautoCompleteOptions] = useState(null);
+  let [entityMatchingDict, setEntityMatchingDict] = useState(null);
   let [questionType, setQuestionType] = useState(query.type);
   let [selectorOptions] = useState([
     { title: "Fact", value: "fact" },
@@ -19,12 +19,28 @@ export default function ValidatorForm({ query, onDelete, onSubmit }) {
     { title: "Statistics", value: "statistics" },
     { title: "Other", value: "other" },
   ]);
+  /** Fetch autcomplete information for tokens */
   let fetchAutoComplete = async () => {
-    let {data} = await axios.get('/entity_structure');
+    let { data } = await axios.get('/entity_structure');
     setautoCompleteOptions(Object.keys(data));
-    console.log(data)
+    buildEntityMatchingDict(data);
   };
   useEffect(fetchAutoComplete, []);
+
+  /**
+   * Builds a dictionary mapping entities and their synonyms to their correct entity
+   */
+  let buildEntityMatchingDict = (entities) => {
+    let entityMatchingDict = {};
+    for (let entity in entities) {
+      entityMatchingDict[entity] = entity
+      for (let syn of entities[entity]['synonyms']) {
+        entityMatchingDict[syn] = entity;
+      }
+    }
+    setEntityMatchingDict(entityMatchingDict);
+  }
+
 
   /** When Query changes, update the internal state of the form */
   let updateQueryState = () => {
@@ -67,14 +83,14 @@ export default function ValidatorForm({ query, onDelete, onSubmit }) {
         value={query.question}
         onChange={setQuestion}
         queryId={query.id}
-        autocompleteOptions={autoCompleteOptions}
+        entityMatchingDict={entityMatchingDict}
       />
       <ValidatorField
         title="Answer"
         value={query.answer}
         onChange={setAnswer}
         queryId={query.id}
-        autocompleteOptions={autoCompleteOptions}
+        entityMatchingDict={entityMatchingDict}
       />
       <div className="query-properties">
         <ValidatorToggle


### PR DESCRIPTION
Changes Added:
- Queried the database for a list of synonyms from each entity
- Take synonyms and create an EntityMatchingDict matching it synonym with its proper token
- When text is typed into a token, search through the dictionary to see if it matches any of the words