### PR TITLE
Attribute autocomplete

### DIFF
--- a/src/pages/Validator/AutocompleteList.js
+++ b/src/pages/Validator/AutocompleteList.js
@@ -2,7 +2,6 @@ import React from "react";
 
 export default function AutocompleteList({
   entities = {},
-  synonyms = {},
   showAttributes,
   inputVal,
   onSelect,
@@ -22,6 +21,14 @@ export default function AutocompleteList({
    */
   let listSynonyms = () => {
     let entitiesSeen = [];
+    // Map entities and their synonyms to their correct entity
+    let synonyms = {};
+    for (let entity in entities) {
+      synonyms[entity] = entity
+      for (let syn of entities[entity]['synonyms']) {
+        synonyms[syn] = entity;
+      }
+    }
     return (
       Object.keys(synonyms)
       .filter(entity => entity.toUpperCase().startsWith(inputVal.toUpperCase()))

--- a/src/pages/Validator/AutocompleteList.js
+++ b/src/pages/Validator/AutocompleteList.js
@@ -2,6 +2,8 @@ import React from "react";
 
 export default function AutocompleteList({
   entities = {},
+  synonyms = {},
+  showAttributes,
   inputVal,
   onSelect,
   onCreate,
@@ -14,24 +16,44 @@ export default function AutocompleteList({
   let entitiesSeen = [];
 
   // Create a list of synonyms, filter them with the input value, and then return a token if the entity isn't already displayed
-  let shownOptions = Object.keys(entities)
+  let showOptions = Object.keys(synonyms)
     .filter((entity) => entity.toUpperCase().startsWith(inputVal.toUpperCase()))
     .map((entity) => {
-      if (!entitiesSeen.includes(entities[entity])) {
-        entitiesSeen.push(entities[entity])
+      if (!entitiesSeen.includes(synonyms[entity])) {
+        entitiesSeen.push(synonyms[entity])
         return (
-          <li key={entity} onClick={handleSelect.bind(this, entities[entity])} >
-            {entities[entity]}
+          <li key={entity} onClick={handleSelect.bind(this, synonyms[entity])} >
+            {synonyms[entity]}
           </li >
         )
       }
     });
 
+    // TODO: filter the attribute names
+    // TODO: fix the onclick handler
+  let listAttributes = () => {
+    let entity = showAttributes;
+    if(!entities[entity]){
+      return
+    }
+    return entities[entity]['attributes'].map((attr) => {
+      return (
+        <li key={attr} onClick={handleSelect.bind(this, synonyms[entity])} >
+          {attr}
+        </li >
+      )
+    })
+  }
+  
+  if (showAttributes) {
+    showOptions = listAttributes()
+  }
+
   // Render the list of tokens, if not display an add token button
   return (
     <ul className="AutocompleteList">
-      {shownOptions.length ? (
-        shownOptions
+      {showOptions.length ? (
+        showOptions
       ) : (
           <li className="add-token" onClick={() => onCreate(inputVal)}>
             Add Token

--- a/src/pages/Validator/AutocompleteList.js
+++ b/src/pages/Validator/AutocompleteList.js
@@ -8,48 +8,61 @@ export default function AutocompleteList({
   onSelect,
   onCreate,
 }) {
-  // Calls onSelect to insert token into the UI
+  /*
+   * Inserts token into the UI, replacing whatever text the user already wrote 
+   * in the token
+   */
   let handleSelect = (entity) => {
     onSelect(entity);
   };
 
-  let entitiesSeen = [];
+  
+  /*
+   * Returns a list of synonym autocomplete options, filtered by the input
+   */
+  let listSynonyms = () => {
+    let entitiesSeen = [];
+    return (
+      Object.keys(synonyms)
+      .filter(entity => entity.toUpperCase().startsWith(inputVal.toUpperCase()))
+      .map((entity) => {
+        if (!entitiesSeen.includes(synonyms[entity])) {
+          entitiesSeen.push(synonyms[entity])
+          return (
+            <li key={entity} onClick={handleSelect.bind(this, synonyms[entity])} >
+              {synonyms[entity]}
+            </li >
+          )
+        }
+      })
+    );
+  };
 
-  // Create a list of synonyms, filter them with the input value, and then return a token if the entity isn't already displayed
-  let showOptions = Object.keys(synonyms)
-    .filter((entity) => entity.toUpperCase().startsWith(inputVal.toUpperCase()))
-    .map((entity) => {
-      if (!entitiesSeen.includes(synonyms[entity])) {
-        entitiesSeen.push(synonyms[entity])
-        return (
-          <li key={entity} onClick={handleSelect.bind(this, synonyms[entity])} >
-            {synonyms[entity]}
-          </li >
-        )
-      }
-    });
-
-    // TODO: filter the attribute names
-    // TODO: fix the onclick handler
+  /*
+   * Returns a list of attribute autocomplete options, filtered by the input
+   */
   let listAttributes = () => {
     let entity = showAttributes;
+    let inputAttr = inputVal.match(/(?<=\.).*/);
     if(!entities[entity]){
       return
     }
-    return entities[entity]['attributes'].map((attr) => {
+    return entities[entity]['attributes']
+      .filter((attr) => attr.includes(inputAttr))
+      .map((attr) => {
       return (
-        <li key={attr} onClick={handleSelect.bind(this, synonyms[entity])} >
+        <li key={attr} onClick={handleSelect.bind(this, `${entity}.${attr}`)} >
           {attr}
         </li >
       )
     })
   }
-  
-  if (showAttributes) {
-    showOptions = listAttributes()
-  }
 
-  // Render the list of tokens, if not display an add token button
+  let showOptions = showAttributes ? listAttributes() : listSynonyms();
+
+  /* 
+   * Render the list of tokens, if not display an add token button
+   */
   return (
     <ul className="AutocompleteList">
       {showOptions.length ? (

--- a/src/pages/Validator/AutocompleteList.js
+++ b/src/pages/Validator/AutocompleteList.js
@@ -24,7 +24,7 @@ export default function AutocompleteList({
     // Map entities and their synonyms to their correct entity
     let synonyms = {};
     for (let entity in entities) {
-      synonyms[entity] = entity
+      synonyms[entity] = entity;
       for (let syn of entities[entity]['synonyms']) {
         synonyms[syn] = entity;
       }
@@ -39,7 +39,7 @@ export default function AutocompleteList({
             <li key={entity} onClick={handleSelect.bind(this, synonyms[entity])} >
               {synonyms[entity]}
             </li >
-          )
+          );
         }
       })
     );
@@ -52,7 +52,7 @@ export default function AutocompleteList({
     let entity = showAttributes;
     let inputAttr = inputVal.match(/(?<=\.).*/);
     if(!entities[entity]){
-      return
+      return;
     }
     return entities[entity]['attributes']
       .filter((attr) => attr.includes(inputAttr))
@@ -61,8 +61,8 @@ export default function AutocompleteList({
         <li key={attr} onClick={handleSelect.bind(this, `${entity}.${attr}`)} >
           {attr}
         </li >
-      )
-    })
+      );
+    });
   }
 
   let showOptions = showAttributes ? listAttributes() : listSynonyms();

--- a/src/pages/Validator/Validator.scss
+++ b/src/pages/Validator/Validator.scss
@@ -225,7 +225,7 @@
   list-style: none;
   width: 100%;
   overflow: hidden;
-  height: 30px;
+  min-height: 30px;
   margin: 5px 0 0 0;
   padding-left: 5px;
   li {

--- a/src/pages/Validator/ValidatorField.js
+++ b/src/pages/Validator/ValidatorField.js
@@ -146,7 +146,6 @@ export default class ValidatorField extends Component {
         {this.state.showAutocomplete && (
           <AutocompleteList
             entities={this.props.entities}
-            synonyms={this.props.entityMatchingDict}
             showAttributes={this.showAttributes()}
             inputVal={this.state.tokenVal}
             onSelect={this.autocompleteVal.bind(this)}

--- a/src/pages/Validator/ValidatorField.js
+++ b/src/pages/Validator/ValidatorField.js
@@ -85,7 +85,7 @@ export default class ValidatorField extends Component {
    * If the name of an entity exists at the start of the token and is followed 
    * by a dot, returns that entities name. Else, returns empty string.
    */
-  showAttributes() {
+  getEntityFromToken() {
     const {tokenVal} = this.state;
     for (let entity in this.props.entities) {
       let regex = new RegExp(`^${entity}\..*`);
@@ -146,10 +146,10 @@ export default class ValidatorField extends Component {
         {this.state.showAutocomplete && (
           <AutocompleteList
             entities={this.props.entities}
-            showAttributes={this.showAttributes()}
+            entityName={this.getEntityFromToken()}
             inputVal={this.state.tokenVal}
             onSelect={this.autocompleteVal.bind(this)}
-            onCreate={this.createToken.bind(this)}
+            onCreateEntity={this.createToken.bind(this)}
           />
         )}
       </div>

--- a/src/pages/Validator/ValidatorField.js
+++ b/src/pages/Validator/ValidatorField.js
@@ -22,7 +22,9 @@ export default class ValidatorField extends Component {
   }
 
   formatQueryHTML(query) {
-    return query.replace(/\[/g, "<u>").replace(/\]/g, "</u>");
+    return query.replace(/\[/g, "<u>")
+                .replace(/\]/g, "</u>")
+                .replace(/\.\./g, ".");
   }
 
   toggleToken(e) {
@@ -102,10 +104,18 @@ export default class ValidatorField extends Component {
     let val = this.formatHTML(e.target.value);
     this.setState({ html: val });
     this.updateAutocomplete();
+    // Reformat phrase to meet database standards
+    // (e.g. braces, double dot, spacing)
     val = val
       .replace(/<u>/g, "[")
       .replace(/<\/u>/g, "]")
       .replace(/&nbsp;/g, "");
+    let dotInToken = /(?<!\.)\.(?!\.)[^\.\[\]]*\]/g;
+    let match = dotInToken.exec(val);
+    while (match) {
+      val = val.slice(0, match.index) + "." + val.slice(match.index);
+      match = dotInToken.exec(val);
+    }
     this.props.onChange(val);
   };
 

--- a/src/pages/Validator/ValidatorField.js
+++ b/src/pages/Validator/ValidatorField.js
@@ -78,6 +78,22 @@ export default class ValidatorField extends Component {
     this.setState({ html: updatedContent });
   }
 
+  /**
+   * Indicates whether attributes should be shown, and for which entity.
+   * If the name of an entity exists at the start of the token and is followed 
+   * by a dot, returns that entities name. Else, returns empty string.
+   */
+  showAttributes() {
+    const {tokenVal} = this.state;
+    for (let entity in this.props.entities) {
+      let regex = new RegExp(`^${entity}\..*`);
+      if (regex.test(tokenVal)) {
+        return tokenVal.match(regex)[0].slice(0, entity.length);
+      }
+    }
+    return "";
+  }
+
   createToken(title) {
     console.log("Create a token with title", title);
   }
@@ -119,7 +135,9 @@ export default class ValidatorField extends Component {
         />
         {this.state.showAutocomplete && (
           <AutocompleteList
-            entities={this.props.entityMatchingDict}
+            entities={this.props.entities}
+            synonyms={this.props.entityMatchingDict}
+            showAttributes={this.showAttributes()}
             inputVal={this.state.tokenVal}
             onSelect={this.autocompleteVal.bind(this)}
             onCreate={this.createToken.bind(this)}

--- a/src/pages/Validator/ValidatorForm.js
+++ b/src/pages/Validator/ValidatorForm.js
@@ -11,8 +11,6 @@ export default function ValidatorForm({ query, onDelete, onSubmit }) {
     query.isAnswerable ? "Yes" : "No"
   );
   let [entities, setEntities] = useState(null);
-  let [autoCompleteOptions, setautoCompleteOptions] = useState(null);
-  let [entityMatchingDict, setEntityMatchingDict] = useState(null);
   let [questionType, setQuestionType] = useState(query.type);
   let [selectorOptions] = useState([
     { title: "Fact", value: "fact" },
@@ -23,26 +21,9 @@ export default function ValidatorForm({ query, onDelete, onSubmit }) {
   /** Fetch autcomplete information for tokens */
   let fetchAutoComplete = async () => {
     let { data } = await axios.get('/entity_structure');
-    setautoCompleteOptions(Object.keys(data).map(s => s.toUpperCase()));
-    buildEntityMatchingDict(data);
     setEntities(data);
   };
   useEffect(() => { fetchAutoComplete(); }, []);
-
-  /**
-   * Builds a dictionary mapping entities and their synonyms to their correct entity
-   */
-  let buildEntityMatchingDict = (entities) => {
-    let entityMatchingDict = {};
-    for (let entity in entities) {
-      entityMatchingDict[entity] = entity
-      for (let syn of entities[entity]['synonyms']) {
-        entityMatchingDict[syn] = entity;
-      }
-    }
-    setEntityMatchingDict(entityMatchingDict);
-  }
-
 
   /** When Query changes, update the internal state of the form */
   let updateQueryState = () => {
@@ -85,7 +66,6 @@ export default function ValidatorForm({ query, onDelete, onSubmit }) {
         value={query.question}
         onChange={setQuestion}
         queryId={query.id}
-        entityMatchingDict={entityMatchingDict}
         entities={entities}
       />
       <ValidatorField
@@ -93,7 +73,6 @@ export default function ValidatorForm({ query, onDelete, onSubmit }) {
         value={query.answer}
         onChange={setAnswer}
         queryId={query.id}
-        entityMatchingDict={entityMatchingDict}
         entities={entities}
       />
       <div className="query-properties">

--- a/src/pages/Validator/ValidatorForm.js
+++ b/src/pages/Validator/ValidatorForm.js
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useCallback } from "react";
+import React, { useState, useEffect } from "react";
 import ValidatorField from "./ValidatorField";
 import ValidatorToggle from "./ValidatorToggle";
 import ValidatorSelector from "./ValidatorSelector";
@@ -10,6 +10,7 @@ export default function ValidatorForm({ query, onDelete, onSubmit }) {
   let [isAnswerable, setAnswerable] = useState(
     query.isAnswerable ? "Yes" : "No"
   );
+  let [entities, setEntities] = useState(null);
   let [autoCompleteOptions, setautoCompleteOptions] = useState(null);
   let [entityMatchingDict, setEntityMatchingDict] = useState(null);
   let [questionType, setQuestionType] = useState(query.type);
@@ -24,8 +25,9 @@ export default function ValidatorForm({ query, onDelete, onSubmit }) {
     let { data } = await axios.get('/entity_structure');
     setautoCompleteOptions(Object.keys(data).map(s => s.toUpperCase()));
     buildEntityMatchingDict(data);
+    setEntities(data);
   };
-  useEffect(fetchAutoComplete, []);
+  useEffect(() => { fetchAutoComplete(); }, []);
 
   /**
    * Builds a dictionary mapping entities and their synonyms to their correct entity
@@ -84,6 +86,7 @@ export default function ValidatorForm({ query, onDelete, onSubmit }) {
         onChange={setQuestion}
         queryId={query.id}
         entityMatchingDict={entityMatchingDict}
+        entities={entities}
       />
       <ValidatorField
         title="Answer"
@@ -91,6 +94,7 @@ export default function ValidatorForm({ query, onDelete, onSubmit }) {
         onChange={setAnswer}
         queryId={query.id}
         entityMatchingDict={entityMatchingDict}
+        entities={entities}
       />
       <div className="query-properties">
         <ValidatorToggle


### PR DESCRIPTION
## Summary
Users can now autocomplete attribute names for every entity using dot syntax.

Specifically, when the user types `ENTITY_NAME.`, all the attributes associated with that entity appear below the input field. As the user continues typing, the list of attributes is filtered based on likely matches.

Clicking an attribute pastes it into the input field.

### Example
User types `CLUB.contact` in a token
Displays `contact_email`, `contact_email_2`, `contact_person`, `contact_phone`
or
User types `PROF.name` in a token
Displays `first_name`, `last_name`

## Notes
Phrases are stored using double dot syntax (e.g. `CLUB..id`), and single dot syntax (e.g. `CLUB.id`) is used only for display and user interaction. The database uses double dot syntax, so whenever updated phrases are published to the database, single dots are automatically converted to double dots.