### PR TITLE
Replace only partial entity name

### DIFF
--- a/src/pages/Validator/ValidatorField.js
+++ b/src/pages/Validator/ValidatorField.js
@@ -74,9 +74,14 @@ export default class ValidatorField extends Component {
     }
   }
 
+  /*
+   * Replaces the partial entity name typed by the user with the complete
+   * entity name provided by 'val'
+   */
   autocompleteVal(val) {
-    //TODO: This replaces first element that matches, even if outside token. Maybe keep track token index and replace only token's innerHTML
-    let updatedContent = this.state.html.replace(this.state.tokenVal, val);
+    let updatedContent = this.state.html.replace(
+      `<u>${this.state.tokenVal}</u>`, `<u>${val}</u>`
+    );
     this.setState({ html: updatedContent });
   }
 


### PR DESCRIPTION
A simple fix to issue #30, where the autocomplete would paste in the wrong location if two entities in the same field shared the same name. This fix looks for the `<u>...</u>` tags to specifically replace the incomplete entity name.