### PR TITLE
Invalid tokens change color

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1078,6 +1078,87 @@
       "resolved": "https://registry.npmjs.org/@csstools/normalize.css/-/normalize.css-10.1.0.tgz",
       "integrity": "sha512-ij4wRiunFfaJxjB0BdrYHIH8FxBJpOwNPhhAcunlmPdXudL1WQV1qoP9un6JsEBAgQH+7UXyyjh0g7jTxXK6tg=="
     },
+    "@emotion/cache": {
+      "version": "10.0.29",
+      "resolved": "https://registry.npmjs.org/@emotion/cache/-/cache-10.0.29.tgz",
+      "integrity": "sha512-fU2VtSVlHiF27empSbxi1O2JFdNWZO+2NFHfwO0pxgTep6Xa3uGb+3pVKfLww2l/IBGLNEZl5Xf/++A4wAYDYQ==",
+      "requires": {
+        "@emotion/sheet": "0.9.4",
+        "@emotion/stylis": "0.8.5",
+        "@emotion/utils": "0.11.3",
+        "@emotion/weak-memoize": "0.2.5"
+      }
+    },
+    "@emotion/core": {
+      "version": "10.0.35",
+      "resolved": "https://registry.npmjs.org/@emotion/core/-/core-10.0.35.tgz",
+      "integrity": "sha512-sH++vJCdk025fBlRZSAhkRlSUoqSqgCzYf5fMOmqqi3bM6how+sQpg3hkgJonj8GxXM4WbD7dRO+4tegDB9fUw==",
+      "requires": {
+        "@babel/runtime": "^7.5.5",
+        "@emotion/cache": "^10.0.27",
+        "@emotion/css": "^10.0.27",
+        "@emotion/serialize": "^0.11.15",
+        "@emotion/sheet": "0.9.4",
+        "@emotion/utils": "0.11.3"
+      }
+    },
+    "@emotion/css": {
+      "version": "10.0.27",
+      "resolved": "https://registry.npmjs.org/@emotion/css/-/css-10.0.27.tgz",
+      "integrity": "sha512-6wZjsvYeBhyZQYNrGoR5yPMYbMBNEnanDrqmsqS1mzDm1cOTu12shvl2j4QHNS36UaTE0USIJawCH9C8oW34Zw==",
+      "requires": {
+        "@emotion/serialize": "^0.11.15",
+        "@emotion/utils": "0.11.3",
+        "babel-plugin-emotion": "^10.0.27"
+      }
+    },
+    "@emotion/hash": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/@emotion/hash/-/hash-0.8.0.tgz",
+      "integrity": "sha512-kBJtf7PH6aWwZ6fka3zQ0p6SBYzx4fl1LoZXE2RrnYST9Xljm7WfKJrU4g/Xr3Beg72MLrp1AWNUmuYJTL7Cow=="
+    },
+    "@emotion/memoize": {
+      "version": "0.7.4",
+      "resolved": "https://registry.npmjs.org/@emotion/memoize/-/memoize-0.7.4.tgz",
+      "integrity": "sha512-Ja/Vfqe3HpuzRsG1oBtWTHk2PGZ7GR+2Vz5iYGelAw8dx32K0y7PjVuxK6z1nMpZOqAFsRUPCkK1YjJ56qJlgw=="
+    },
+    "@emotion/serialize": {
+      "version": "0.11.16",
+      "resolved": "https://registry.npmjs.org/@emotion/serialize/-/serialize-0.11.16.tgz",
+      "integrity": "sha512-G3J4o8by0VRrO+PFeSc3js2myYNOXVJ3Ya+RGVxnshRYgsvErfAOglKAiy1Eo1vhzxqtUvjCyS5gtewzkmvSSg==",
+      "requires": {
+        "@emotion/hash": "0.8.0",
+        "@emotion/memoize": "0.7.4",
+        "@emotion/unitless": "0.7.5",
+        "@emotion/utils": "0.11.3",
+        "csstype": "^2.5.7"
+      }
+    },
+    "@emotion/sheet": {
+      "version": "0.9.4",
+      "resolved": "https://registry.npmjs.org/@emotion/sheet/-/sheet-0.9.4.tgz",
+      "integrity": "sha512-zM9PFmgVSqBw4zL101Q0HrBVTGmpAxFZH/pYx/cjJT5advXguvcgjHFTCaIO3enL/xr89vK2bh0Mfyj9aa0ANA=="
+    },
+    "@emotion/stylis": {
+      "version": "0.8.5",
+      "resolved": "https://registry.npmjs.org/@emotion/stylis/-/stylis-0.8.5.tgz",
+      "integrity": "sha512-h6KtPihKFn3T9fuIrwvXXUOwlx3rfUvfZIcP5a6rh8Y7zjE3O06hT5Ss4S/YI1AYhuZ1kjaE/5EaOOI2NqSylQ=="
+    },
+    "@emotion/unitless": {
+      "version": "0.7.5",
+      "resolved": "https://registry.npmjs.org/@emotion/unitless/-/unitless-0.7.5.tgz",
+      "integrity": "sha512-OWORNpfjMsSSUBVrRBVGECkhWcULOAJz9ZW8uK9qgxD+87M7jHRcvh/A96XXNhXTLmKcoYSQtBEX7lHMO7YRwg=="
+    },
+    "@emotion/utils": {
+      "version": "0.11.3",
+      "resolved": "https://registry.npmjs.org/@emotion/utils/-/utils-0.11.3.tgz",
+      "integrity": "sha512-0o4l6pZC+hI88+bzuaX/6BgOvQVhbt2PfmxauVaYOGgbsAw14wdKyvMCZXnsnsHys94iadcF+RG/wZyx6+ZZBw=="
+    },
+    "@emotion/weak-memoize": {
+      "version": "0.2.5",
+      "resolved": "https://registry.npmjs.org/@emotion/weak-memoize/-/weak-memoize-0.2.5.tgz",
+      "integrity": "sha512-6U71C2Wp7r5XtFtQzYrW5iKFT67OixrSxjI4MptCHzdSVlgabczzqLe0ZSgnub/5Kp4hSbpDB1tMytZY9pwxxA=="
+    },
     "@firebase/analytics": {
       "version": "0.3.5",
       "resolved": "https://registry.npmjs.org/@firebase/analytics/-/analytics-0.3.5.tgz",
@@ -2870,6 +2951,37 @@
       "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.10.0.tgz",
       "integrity": "sha512-3YDiu347mtVtjpyV3u5kVqQLP242c06zwDOgpeRnybmXlYYsLbtTrUBUm8i8srONt+FWobl5aibnU1030PeeuA=="
     },
+    "axios": {
+      "version": "0.19.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.19.2.tgz",
+      "integrity": "sha512-fjgm5MvRHLhx+osE2xoekY70AhARk3a6hkN+3Io1jc00jtquGvxYlKlsFUhmUET0V5te6CcZI7lcv2Ym61mjHA==",
+      "requires": {
+        "follow-redirects": "1.5.10"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "follow-redirects": {
+          "version": "1.5.10",
+          "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.5.10.tgz",
+          "integrity": "sha512-0V5l4Cizzvqt5D44aTXbFZz+FtyXV1vrDN6qrelxtfYQKW0KO0W2T/hkE8xvGa/540LkZlkaUjO4ailYTFtHVQ==",
+          "requires": {
+            "debug": "=3.1.0"
+          }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+        }
+      }
+    },
     "axobject-query": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/axobject-query/-/axobject-query-2.1.2.tgz",
@@ -2989,6 +3101,23 @@
         "object.assign": "^4.1.0"
       }
     },
+    "babel-plugin-emotion": {
+      "version": "10.0.33",
+      "resolved": "https://registry.npmjs.org/babel-plugin-emotion/-/babel-plugin-emotion-10.0.33.tgz",
+      "integrity": "sha512-bxZbTTGz0AJQDHm8k6Rf3RQJ8tX2scsfsRyKVgAbiUPUNIRtlK+7JxP+TAd1kRLABFxe0CFm2VdK4ePkoA9FxQ==",
+      "requires": {
+        "@babel/helper-module-imports": "^7.0.0",
+        "@emotion/hash": "0.8.0",
+        "@emotion/memoize": "0.7.4",
+        "@emotion/serialize": "^0.11.16",
+        "babel-plugin-macros": "^2.0.0",
+        "babel-plugin-syntax-jsx": "^6.18.0",
+        "convert-source-map": "^1.5.0",
+        "escape-string-regexp": "^1.0.5",
+        "find-root": "^1.1.0",
+        "source-map": "^0.5.7"
+      }
+    },
     "babel-plugin-istanbul": {
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-istanbul/-/babel-plugin-istanbul-5.2.0.tgz",
@@ -3106,6 +3235,11 @@
       "version": "0.3.6",
       "resolved": "https://registry.npmjs.org/babel-plugin-named-asset-import/-/babel-plugin-named-asset-import-0.3.6.tgz",
       "integrity": "sha512-1aGDUfL1qOOIoqk9QKGIo2lANk+C7ko/fqH0uIyC71x3PEGz0uVP8ISgfEsFuG+FKmjHTvFK/nNM8dowpmUxLA=="
+    },
+    "babel-plugin-syntax-jsx": {
+      "version": "6.18.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-jsx/-/babel-plugin-syntax-jsx-6.18.0.tgz",
+      "integrity": "sha1-CvMqmm4Tyno/1QaeYtew9Y0NiUY="
     },
     "babel-plugin-syntax-object-rest-spread": {
       "version": "6.13.0",
@@ -6164,6 +6298,11 @@
         "make-dir": "^2.0.0",
         "pkg-dir": "^3.0.0"
       }
+    },
+    "find-root": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/find-root/-/find-root-1.1.0.tgz",
+      "integrity": "sha512-NKfW6bec6GfKc0SGx1e07QZY9PE99u0Bft/0rzSD5k3sO/vwkVUpDUKVm5Gpp5Ue3YfShPFTX2070tDs5kB9Ng=="
     },
     "find-up": {
       "version": "2.1.0",

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
+    "@emotion/core": "^10.0.35",
     "@testing-library/jest-dom": "^4.2.4",
     "@testing-library/react": "^9.5.0",
     "@testing-library/user-event": "^7.2.1",

--- a/public/index.html
+++ b/public/index.html
@@ -39,6 +39,7 @@
       To begin the development, run `npm start` or `yarn start`.
       To create a production bundle, use `npm run build` or `yarn build`.
     -->
-    <script src="https://unpkg.com/ionicons@5.1.2/dist/ionicons.js"></script>
+    <script type="module" src="https://unpkg.com/ionicons@5.1.2/dist/ionicons/ionicons.esm.js"></script>
+    <script nomodule="" src="https://unpkg.com/ionicons@5.1.2/dist/ionicons/ionicons.js"></script>
   </body>
 </html>

--- a/src/App.js
+++ b/src/App.js
@@ -10,12 +10,13 @@ import SignUp from "./pages/SignUp/SignUp";
 import Validator from "./pages/Validator/Validator";
 
 function App() {
-  let [user, setUser] = useState(null);
+  // Currently, we are not using the user, but we could in the future.
+  // let [user, setUser] = useState(null);
   let [signedIn, setSignedIn] = useState(false);
 
   let mountFirebaseAuth = () => {
     auth.onAuthStateChanged((user) => {
-      setUser(auth.currentUser);
+      // setUser(auth.currentUser);
       user ? setSignedIn(true) : setSignedIn(false);
     });
   };

--- a/src/App.scss
+++ b/src/App.scss
@@ -14,6 +14,7 @@ body,
   --backdrop: #faf4ff;
   --confirm: #53df8e;
   --deny: #ff7b7b;
+  --invalid: #ffb677;
 }
 
 h1,

--- a/src/components/LoginHero/LoginHero.js
+++ b/src/components/LoginHero/LoginHero.js
@@ -14,7 +14,6 @@ const sleep = (ms) => new Promise(resolve => {
     }, ms)
 })
 
-
 export default function LoginHero() {
     let messages = ["Hello Nimbus",
         "Nimbus, consider yourself validated",
@@ -29,9 +28,18 @@ export default function LoginHero() {
     }} key={i} > {char}</ span >);
 
     let animateLetters = () => {
+        
         let letters = [...messageRef.current.children];
         const animationDuration = 1000
         const displayTime = 5000
+        let isOnScreen = true;
+        // NOTE: isOnScreen currently will NOT be set to false when the user changes the screen, which is the opposite of what we want
+        const cleanup = () => {
+            // TODO: Make a cleanup function that stops the memory leak error.
+            letters.forEach(letter => letter.getAnimations().forEach(anim => anim.cancel()));
+            isOnScreen = false
+        }
+
         const letterAnimationState = letters.map(async (letter, i) => {
             let delay = i * 100;
 
@@ -45,11 +53,14 @@ export default function LoginHero() {
             // easing: easInOutBack from https://easings.net/#easeInOutBack
             let anim = letter.animate(keyframes, { duration: animationDuration, easing: 'cubic-bezier(0.68, -0.6, 0.32, 1.6)', delay: delay, fill: "forwards" });
             await sleep(animationDuration + displayTime)
+            if(!isOnScreen) return cleanup
             anim.reverse()
             await sleep(animationDuration)
         });
 
         Promise.all(letterAnimationState).then(() => setIndex(i => (i + 1) % messages.length))
+
+        return cleanup;
     }
 
     useEffect(animateLetters, [messageRef, index]);

--- a/src/components/SignOut/SignOut.js
+++ b/src/components/SignOut/SignOut.js
@@ -20,9 +20,9 @@ export default function SignOut(props) {
 
   return (
     <div className="SignOut">
-      <button className="signOut-button" onClick={signOutUser}>
+      <p className="signOut-button" onClick={signOutUser}>
         Sign Out
-      </button>
+      </p>
     </div>
   );
 }

--- a/src/components/SignOut/SignOut.scss
+++ b/src/components/SignOut/SignOut.scss
@@ -1,34 +1,17 @@
 .SignOut {
   .signOut-button {
-    width: max-content;
-    height: 40px;
-    margin: 30px auto 10px;
-    padding: 0 15px;
-    outline: none;
-    font-size: 16px;
+    margin: 0;
+    padding: 0;
+    font-size: 12px;
     font-weight: bold;
-    background: none;
-    color: #414141;
-    border: 1px solid #414141;
-    border-radius: 4px;
     cursor: pointer;
+    opacity: 0.6;
+    transition: all 0.2s;
 
     @media (hover: hover) and (pointer: fine) {
       &:hover {
-        color: white;
-        border: none;
-        background: rgb(113, 204, 217);
-        background: linear-gradient(
-          135deg,
-          rgba(113, 204, 217, 1) 0%,
-          rgba(128, 85, 162, 1) 65%,
-          rgba(128, 85, 162, 1) 100%
-        );
+        opacity: 1;
       }
-    }
-    &:active {
-      transition: all 0.025s ease;
-      transform: translate(0, 1px);
     }
   }
 }

--- a/src/pages/Login/Login.js
+++ b/src/pages/Login/Login.js
@@ -21,7 +21,7 @@ export default function Login(props) {
     e.preventDefault();
     if (!formIsValid()) return;
     try {
-      const user = await auth.signInWithEmailAndPassword(username, password);
+      await auth.signInWithEmailAndPassword(username, password);
     } catch (err) {
       alert(err.message);
       return;

--- a/src/pages/Validator/AllValidated.js
+++ b/src/pages/Validator/AllValidated.js
@@ -8,7 +8,6 @@ export default function AllValidated() {
     height: "auto",
   };
 
-  let signOut = () => console.log("sign out");
   return (
     <div className="AllValidated">
       <FinishedHiro style={hiroStyles} />

--- a/src/pages/Validator/AutocompleteList.js
+++ b/src/pages/Validator/AutocompleteList.js
@@ -44,6 +44,7 @@ export default function AutocompleteList({
             </li >
           );
         }
+        else return null;
       })
     );
   };

--- a/src/pages/Validator/TokenCreator.js
+++ b/src/pages/Validator/TokenCreator.js
@@ -1,0 +1,16 @@
+import React from 'react'
+
+export default function TokenCreator({ onDismiss }) {
+
+    return (<div className="TokenCreator">
+        <div className="modal-background" onClick={onDismiss}>
+        <div className="modal">
+            <h2>Token Creator</h2>
+            <p>In the future, you'll be able to create your own tokens, but not right now :)</p>
+            </div>
+        </div>
+
+
+    </div>)
+
+}

--- a/src/pages/Validator/Validator.js
+++ b/src/pages/Validator/Validator.js
@@ -93,7 +93,6 @@ export default function Validator(props) {
         onDelete={deleteCurrentQuery}
         onSubmit={getNextQuery}
       />
-      <TokenBar />
       <ValidatorQueryNav
         queries={queries}
         selectedIndex={selectedIndex}

--- a/src/pages/Validator/Validator.js
+++ b/src/pages/Validator/Validator.js
@@ -1,7 +1,6 @@
 import React, { useState, useEffect } from "react";
 import "./Validator.scss";
 import ValidatorForm from "./ValidatorForm";
-import TokenBar from "./TokenBar";
 import ValidatorQueryNav from "./ValidatorQueryNav";
 import AllValidated from "./AllValidated";
 import axios from "axios";
@@ -45,7 +44,7 @@ export default function Validator(props) {
       answer: submittedQuery.answer.replace(regex, "").replace(nonSpacedToken, " "),
       verified: true,
     };
-    let response = await axios.post(`/new_data/update_phrase`, data);
+    await axios.post(`/new_data/update_phrase`, data);
 
     if (updatedQueries.length - 2 <= selectedIndex)
       await fetchMoreQueries(1, updatedQueries);
@@ -81,7 +80,13 @@ export default function Validator(props) {
   };
   useEffect(() => {
     fetchMoreQueries(3, queries);
+    /** DO NOT REMOVE THE COMMENT BELOW! It prevents an error from being raised 
+     * that is caused by the empty dependency array in useEffect here. 
+     * https://stackoverflow.com/questions/55840294/how-to-fix-missing-dependency-warning-when-using-useeffect-react-hook
+     */
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
+
   // TODO: Build a loading page while queries are initially fetched
   if (!queries.length) return <AllValidated />;
 

--- a/src/pages/Validator/Validator.scss
+++ b/src/pages/Validator/Validator.scss
@@ -152,7 +152,7 @@
     }
 
     .selection-indicator {
-      transition: left 0.5s ease-in-out;
+      transition: left 0.15s ease-in-out;
       position: absolute;
       background: white;
       padding: 10px;
@@ -174,6 +174,7 @@
     border-radius: 16px;
     padding: 5px 20px;
     width: 150px;
+    cursor: pointer;
   }
 }
 
@@ -184,6 +185,39 @@
   height: 70%;
   width: 90%;
   min-height: 400px;
+}
+
+.TokenCreator {
+  position: absolute;
+  z-index: 5;
+  top: 0;
+  left:0;
+  width: 100vw;
+  height: 100vh;
+
+  .modal-background {
+    width: 100%;
+    height: 100%;
+    background-color: rgba(0,0,0, 0.3);
+    display:flex;
+    justify-content: center;
+    align-items: center;
+  }
+
+  .modal {
+
+    h2 {
+      text-align: center;
+    }
+    
+    min-width: 300px;
+    width: 60%;
+    height: min-content;
+    padding: 30px;
+    border-radius: 10px;
+    background: white;
+    text-align: center;
+  }
 }
 
 .ValidatorQueryNav {
@@ -217,6 +251,14 @@
       border-color: var(--confirm);
     }
   }
+}
+
+.SignOut {
+  grid-area: form;
+  // position: absolute;
+  // top: 8%;
+  // left: 65%;
+  // transform: translate(-50%, -50%);
 }
 
 .AllValidated {

--- a/src/pages/Validator/ValidatorField.js
+++ b/src/pages/Validator/ValidatorField.js
@@ -147,14 +147,10 @@ export default class ValidatorField extends Component {
       (tokenVal === entity && entity !== "") ||
       (tokenVal === `${entity}.${attr}` && entity !== "" && attr !== "")
     );
-    let mustUpdateStyle = (
-      (html.indexOf(tagWithStyle) > -1 || html.indexOf(plainTag) > -1) &&
-      tokenVal.length > 1
-    );
 
-    if (isValidToken && mustUpdateStyle) {
+    if (isValidToken && html.indexOf(tagWithStyle) > -1) {
       html = html.replace(tagWithStyle, plainTag);
-    } else if (!isValidToken && mustUpdateStyle) {
+    } else if (!isValidToken && html.indexOf(plainTag) > -1) {
       html = html.replace(plainTag, tagWithStyle);
     }
     return html;

--- a/src/pages/Validator/ValidatorField.js
+++ b/src/pages/Validator/ValidatorField.js
@@ -167,7 +167,8 @@ export default class ValidatorField extends Component {
     html = html
       .replace(/<u[^>]*>/g, "[")
       .replace(/<\/u>/g, "]")
-      .replace(/&nbsp;/g, " ");
+      .replace(/&nbsp;/g, " ")
+      .replace(/<\/?span[^>]*>/g, "");
     let dotInToken = /(?<!\.)\.(?!\.)[^\.\[\]]*\]/g;
     let match = dotInToken.exec(html);
     while (match) {

--- a/src/pages/Validator/ValidatorField.js
+++ b/src/pages/Validator/ValidatorField.js
@@ -19,6 +19,12 @@ export default class ValidatorField extends Component {
     this.setState({ html: this.formatQueryHTML(this.props.value) });
   }
 
+  /* If a different query is navigated to, display the new text. */
+  componentDidUpdate(prevProps) {
+    if (this.props !== prevProps)
+      this.setState({ html: this.formatQueryHTML(this.props.value) });
+  }
+
   formatQueryHTML(query) {
     return query.replace(/\[/g, "<u>")
                 .replace(/\]/g, "</u>")
@@ -82,11 +88,12 @@ export default class ValidatorField extends Component {
    * Hides the autocomplete options after replacement.
    */
   autocompleteVal(val) {
-    let updatedContent = this.state.html.replace(
+    let updatedHTML = this.state.html.replace(
       `>${this.state.tokenVal}</u>`, `>${val}</u>`
     );
-    this.updateTokenColor(updatedContent);
-    this.setState({ html: updatedContent, showAutocomplete: false });
+    this.updateTokenColor(updatedHTML);
+    this.updateQueryData(updatedHTML);
+    this.setState({ html: updatedHTML, showAutocomplete: false });
   }
 
 /*

--- a/src/pages/Validator/ValidatorField.js
+++ b/src/pages/Validator/ValidatorField.js
@@ -78,17 +78,20 @@ export default class ValidatorField extends Component {
     return filteredHTML;
   }
 
-  updateAutocomplete() {
+  getSelectedToken() {
     let sel = window.getSelection();
     let isToken = sel?.anchorNode?.parentElement?.nodeName === "U";
-    if (isToken) {
+    return isToken ? sel.anchorNode.wholeText : "";
+  }
+
+  updateAutocomplete(tokenVal) {
+    if (tokenVal) {
       this.setState({ showAutocomplete: true });
-      this.setState({ tokenVal: sel.anchorNode.wholeText });
+      this.setState({ tokenVal: tokenVal });
     } else {
       this.setState({ showAutocomplete: false });
       this.setState({ tokenVal: "" });
     }
-    return isToken ? sel.anchorNode.wholeText : "";
   }
 
   /*
@@ -99,6 +102,7 @@ export default class ValidatorField extends Component {
     let updatedContent = this.state.html.replace(
       `>${this.state.tokenVal}</u>`, `>${val}</u>`
     );
+    debugger
     updatedContent = this.updateTokenColor(updatedContent, val);
     this.setState({ html: updatedContent });
   }
@@ -147,7 +151,6 @@ export default class ValidatorField extends Component {
       (tokenVal === entity && entity !== "") ||
       (tokenVal === `${entity}.${attr}` && entity !== "" && attr !== "")
     );
-
     if (isValidToken && html.indexOf(tagWithStyle) > -1) {
       html = html.replace(tagWithStyle, plainTag);
     } else if (!isValidToken && html.indexOf(plainTag) > -1) {
@@ -178,10 +181,11 @@ export default class ValidatorField extends Component {
 
   handleTextInput = (e) => {
     let newHTML = this.formatHTML(e.target.value);
-    let newTokenVal = this.updateAutocomplete();
+    const selectedToken = this.getSelectedToken();
     // Why is this line causing the component to re-render?
-    newHTML = this.updateTokenColor(newHTML, newTokenVal);
+    newHTML = this.updateTokenColor(newHTML, selectedToken);
     this.setState({ html: newHTML });
+    this.updateAutocomplete(selectedToken);
     this.updateQueryData(newHTML);
   };
 
@@ -200,7 +204,7 @@ export default class ValidatorField extends Component {
         <h3 className="field-title">{this.props.title}</h3>
         <ContentEditable
           onBlur={this.toggleFocus.bind(this)}
-          onClick={this.updateAutocomplete.bind(this)}
+          onClick={() => this.updateAutocomplete(this.getSelectedToken())}
           onFocus={this.toggleFocus.bind(this)}
           onKeyDown={this.toggleToken.bind(this)}
           className="text-field"

--- a/src/pages/Validator/ValidatorField.js
+++ b/src/pages/Validator/ValidatorField.js
@@ -133,11 +133,15 @@ export default class ValidatorField extends Component {
   updateTokenColor(val, tokenVal) {
     let entity = this.getEntityFromToken(tokenVal);
     let attr = this.getAttributeFromToken(entity, tokenVal);
-    let tagWithStyle = `<u style="background:var(--invalid);">${tokenVal}`;
-    let plainTag = `<u>${tokenVal}`;
+    let tagWithStyle = `<u style="background:var(--invalid);">${tokenVal}<`;
+    let plainTag = `<u>${tokenVal}<`;
     let isValidToken = (
       (tokenVal === entity && entity !== "") ||
       (tokenVal === `${entity}.${attr}` && entity !== "" && attr !== "")
+    );
+    let mustUpdateStyle = (
+      (val.indexOf(tagWithStyle) > -1 || val.indexOf(plainTag) > -1) &&
+      tokenVal.length > 1
     );
 
     // console.log(`HTML: ${val}`)
@@ -145,13 +149,10 @@ export default class ValidatorField extends Component {
     // console.log(`entity: ${entity}`)
     // console.log(`attribute: ${attr}`)
 
-    if (isValidToken) {
-      // Check if the tag style needs to be updated
-      if (val.indexOf(tagWithStyle) > -1 && tokenVal.length > 1)
-        val = val.replace(tagWithStyle, plainTag);
-    } else {
-      if (val.indexOf(plainTag) > -1 && tokenVal.length > 1)
-        val = val.replace(plainTag, tagWithStyle);
+    if (isValidToken && mustUpdateStyle) {
+      val = val.replace(tagWithStyle, plainTag);
+    } else if (!isValidToken && mustUpdateStyle) {
+      val = val.replace(plainTag, tagWithStyle);
     }
     return val;
   }

--- a/src/pages/Validator/ValidatorField.js
+++ b/src/pages/Validator/ValidatorField.js
@@ -99,6 +99,7 @@ export default class ValidatorField extends Component {
     let updatedContent = this.state.html.replace(
       `>${this.state.tokenVal}</u>`, `>${val}</u>`
     );
+    updatedContent = this.updateTokenColor(updatedContent, val);
     this.setState({ html: updatedContent });
   }
 
@@ -130,7 +131,14 @@ export default class ValidatorField extends Component {
     return tokenAttr;
   }
 
-  updateTokenColor(val, tokenVal) {
+  /*
+   * Changes a token's color if it is valid by adding/removing inline styles.
+   * Takes the current field's html and token text, and updates the color if 
+   * the token:
+   * - doesn't contain an entity in the list of queried entities
+   * - contains a valid entity followed by a dot, but has an invalid attribute
+   */
+  updateTokenColor(html, tokenVal) {
     let entity = this.getEntityFromToken(tokenVal);
     let attr = this.getAttributeFromToken(entity, tokenVal);
     let tagWithStyle = `<u style="background:var(--invalid);">${tokenVal}<`;
@@ -140,21 +148,21 @@ export default class ValidatorField extends Component {
       (tokenVal === `${entity}.${attr}` && entity !== "" && attr !== "")
     );
     let mustUpdateStyle = (
-      (val.indexOf(tagWithStyle) > -1 || val.indexOf(plainTag) > -1) &&
+      (html.indexOf(tagWithStyle) > -1 || html.indexOf(plainTag) > -1) &&
       tokenVal.length > 1
     );
 
-    // console.log(`HTML: ${val}`)
+    // console.log(`HTML: ${html}`)
     // console.log(`tokenVal: ${tokenVal}`)
     // console.log(`entity: ${entity}`)
     // console.log(`attribute: ${attr}`)
 
     if (isValidToken && mustUpdateStyle) {
-      val = val.replace(tagWithStyle, plainTag);
+      html = html.replace(tagWithStyle, plainTag);
     } else if (!isValidToken && mustUpdateStyle) {
-      val = val.replace(plainTag, tagWithStyle);
+      html = html.replace(plainTag, tagWithStyle);
     }
-    return val;
+    return html;
   }
 
   createToken(title) {

--- a/src/pages/Validator/ValidatorField.js
+++ b/src/pages/Validator/ValidatorField.js
@@ -2,7 +2,6 @@
 
 import React, { Component } from "react";
 import { css, jsx } from '@emotion/core'
-import Token from "./Token";
 import ContentEditable from "react-contenteditable";
 import AutocompleteList from "./AutocompleteList";
 export default class ValidatorField extends Component {
@@ -158,7 +157,7 @@ export default class ValidatorField extends Component {
   }
 
   createToken(title) {
-    console.log("Create a token with title", title);
+    this.props.onCreateToken(title);
   }
 
   updateQueryData(html) {
@@ -169,7 +168,7 @@ export default class ValidatorField extends Component {
       .replace(/<\/u>/g, "]")
       .replace(/&nbsp;/g, " ")
       .replace(/<\/?span[^>]*>/g, "");
-    let dotInToken = /(?<!\.)\.(?!\.)[^\.\[\]]*\]/g;
+    let dotInToken = /(?<!\.)\.(?!\.)[^.[\]]*\]/g;
     let match = dotInToken.exec(html);
     while (match) {
       html = html.slice(0, match.index) + "." + html.slice(match.index);

--- a/src/pages/Validator/ValidatorField.js
+++ b/src/pages/Validator/ValidatorField.js
@@ -34,7 +34,7 @@ export default class ValidatorField extends Component {
   }
 
   toggleFocus() {
-    this.updateAutocomplete();
+    this.updateAutocomplete(this.getSelectedToken());
     this.checkTokenValidity();
     this.setState((state) => ({
       isFocused: !state.isFocused,
@@ -106,8 +106,7 @@ export default class ValidatorField extends Component {
     let updatedContent = this.state.html.replace(
       `>${this.state.tokenVal}</u>`, `>${val}</u>`
     );
-   //this.updateTokenColor(updatedContent, val);
-   console.log({ html: updatedContent })
+    this.updateTokenColor(updatedContent, val);
     this.setState({ html: updatedContent });
   }
 
@@ -209,7 +208,7 @@ export default class ValidatorField extends Component {
     let newHTML = this.formatHTML(e.target.value);
     const selectedToken = this.getSelectedToken();
     // Why is this line causing the component to re-render?
-    // this.updateTokenColor(newHTML, selectedToken);
+    this.updateTokenColor(newHTML, selectedToken);
     this.updateAutocomplete(selectedToken);
     this.setState({ html: newHTML });
     this.updateQueryData(newHTML);
@@ -240,7 +239,6 @@ export default class ValidatorField extends Component {
         ></div>
         <h3 className="field-title">{this.props.title}</h3>
         <ContentEditable
-          
           onBlur={this.toggleFocus.bind(this)}
           onClick={() => this.updateAutocomplete(this.getSelectedToken())}
           onFocus={this.toggleFocus.bind(this)}

--- a/src/pages/Validator/ValidatorField.js
+++ b/src/pages/Validator/ValidatorField.js
@@ -141,8 +141,8 @@ export default class ValidatorField extends Component {
   updateTokenColor(html, tokenVal) {
     let entity = this.getEntityFromToken(tokenVal);
     let attr = this.getAttributeFromToken(entity, tokenVal);
-    let tagWithStyle = `<u style="background:var(--invalid);">${tokenVal}<`;
-    let plainTag = `<u>${tokenVal}<`;
+    let tagWithStyle = `<u style="background:var(--invalid);">${tokenVal}</u>`;
+    let plainTag = `<u>${tokenVal}</u>`;
     let isValidToken = (
       (tokenVal === entity && entity !== "") ||
       (tokenVal === `${entity}.${attr}` && entity !== "" && attr !== "")
@@ -151,11 +151,6 @@ export default class ValidatorField extends Component {
       (html.indexOf(tagWithStyle) > -1 || html.indexOf(plainTag) > -1) &&
       tokenVal.length > 1
     );
-
-    // console.log(`HTML: ${html}`)
-    // console.log(`tokenVal: ${tokenVal}`)
-    // console.log(`entity: ${entity}`)
-    // console.log(`attribute: ${attr}`)
 
     if (isValidToken && mustUpdateStyle) {
       html = html.replace(tagWithStyle, plainTag);
@@ -169,24 +164,29 @@ export default class ValidatorField extends Component {
     console.log("Create a token with title", title);
   }
 
-  handleTextInput = (e) => {
-    let val = this.formatHTML(e.target.value);
-    let newTokenVal = this.updateAutocomplete();
-    val = this.updateTokenColor(val, newTokenVal);
-    this.setState({ html: val });
+  updateQueryData(html) {
     // Reformat phrase to meet database standards
     // (e.g. braces, double dot, spacing)
-    val = val
+    html = html
       .replace(/<u[^>]*>/g, "[")
       .replace(/<\/u>/g, "]")
       .replace(/&nbsp;/g, " ");
     let dotInToken = /(?<!\.)\.(?!\.)[^\.\[\]]*\]/g;
-    let match = dotInToken.exec(val);
+    let match = dotInToken.exec(html);
     while (match) {
-      val = val.slice(0, match.index) + "." + val.slice(match.index);
-      match = dotInToken.exec(val);
+      html = html.slice(0, match.index) + "." + html.slice(match.index);
+      match = dotInToken.exec(html);
     }
-    this.props.onChange(val);
+    this.props.onChange(html);
+  }
+
+  handleTextInput = (e) => {
+    let newHTML = this.formatHTML(e.target.value);
+    let newTokenVal = this.updateAutocomplete();
+    // Why is this line causing the component to re-render?
+    newHTML = this.updateTokenColor(newHTML, newTokenVal);
+    this.setState({ html: newHTML });
+    this.updateQueryData(newHTML);
   };
 
   render() {

--- a/src/pages/Validator/ValidatorField.js
+++ b/src/pages/Validator/ValidatorField.js
@@ -17,8 +17,8 @@ export default class ValidatorField extends Component {
 
   formatQueryHTML(query) {
     return query.replace(/\[/g, "<u>")
-      .replace(/\]/g, "</u>")
-      .replace(/\.\./g, ".");
+                .replace(/\]/g, "</u>")
+                .replace(/\.\./g, ".");
   }
 
   toggleToken(e) {

--- a/src/pages/Validator/ValidatorField.js
+++ b/src/pages/Validator/ValidatorField.js
@@ -17,8 +17,8 @@ export default class ValidatorField extends Component {
 
   formatQueryHTML(query) {
     return query.replace(/\[/g, "<u>")
-                .replace(/\]/g, "</u>")
-                .replace(/\.\./g, ".");
+      .replace(/\]/g, "</u>")
+      .replace(/\.\./g, ".");
   }
 
   toggleToken(e) {

--- a/src/pages/Validator/ValidatorField.js
+++ b/src/pages/Validator/ValidatorField.js
@@ -136,6 +136,20 @@ export default class ValidatorField extends Component {
   }
 
   /*
+  * Returns natural index of the token that starts at the provided index in the 
+  * html string.
+  * Takes an html string and slices from it start up to the endIndex
+  */
+  getTokenChildIndex(html, endIndex) {
+    let precedingText = html.slice(0, endIndex);
+    let closingTag = /<\/u>/g;
+    let matchCount = precedingText.match(closingTag)
+
+    // matchCount is either null or an array
+    return (matchCount) ? matchCount.length + 1 : 1;
+  }
+
+  /*
    * Changes a token's color if it is valid by adding/removing inline styles.
    * Takes the current field's html and token text, and updates the color if 
    * the token:
@@ -151,10 +165,25 @@ export default class ValidatorField extends Component {
       (tokenVal === entity && entity !== "") ||
       (tokenVal === `${entity}.${attr}` && entity !== "" && attr !== "")
     );
-    if (isValidToken && html.indexOf(tagWithStyle) > -1) {
-      html = html.replace(tagWithStyle, plainTag);
-    } else if (!isValidToken && html.indexOf(plainTag) > -1) {
-      html = html.replace(plainTag, tagWithStyle);
+    // if (isValidToken && html.indexOf(tagWithStyle) > -1) {
+    //   // html = html.replace(tagWithStyle, plainTag);
+    // } else if (!isValidToken && html.indexOf(plainTag) > -1) {
+    //   // html = html.replace(plainTag, tagWithStyle);
+    // }
+    let tokenIndex;
+    if (tokenVal !== "") {
+      tokenIndex = this.getTokenChildIndex(html, html.indexOf(plainTag))
+      console.log(tokenIndex)
+      // TODO: use the token index with nth-child to style the token
+        /*
+
+        .text-field {
+          u:nth-child(2) {
+            --token-color: red;
+          }
+        }
+
+        */
     }
     return html;
   }
@@ -184,8 +213,8 @@ export default class ValidatorField extends Component {
     const selectedToken = this.getSelectedToken();
     // Why is this line causing the component to re-render?
     newHTML = this.updateTokenColor(newHTML, selectedToken);
+   // this.updateAutocomplete(selectedToken);
     this.setState({ html: newHTML });
-    this.updateAutocomplete(selectedToken);
     this.updateQueryData(newHTML);
   };
 

--- a/src/pages/Validator/ValidatorField.js
+++ b/src/pages/Validator/ValidatorField.js
@@ -88,6 +88,7 @@ export default class ValidatorField extends Component {
       this.setState({ showAutocomplete: false });
       this.setState({ tokenVal: "" });
     }
+    return isToken ? sel.anchorNode.wholeText : "";
   }
 
   /*
@@ -129,18 +130,45 @@ export default class ValidatorField extends Component {
     return tokenAttr;
   }
 
+  updateTokenColor(val, tokenVal) {
+    let entity = this.getEntityFromToken(tokenVal);
+    let attr = this.getAttributeFromToken(entity, tokenVal);
+    let tagWithStyle = `<u style="background:var(--invalid);">${tokenVal}`;
+    let plainTag = `<u>${tokenVal}`;
+    let isValidToken = (
+      (tokenVal === entity && entity !== "") ||
+      (tokenVal === `${entity}.${attr}` && entity !== "" && attr !== "")
+    );
+
+    // console.log(`HTML: ${val}`)
+    // console.log(`tokenVal: ${tokenVal}`)
+    // console.log(`entity: ${entity}`)
+    // console.log(`attribute: ${attr}`)
+
+    if (isValidToken) {
+      // Check if the tag style needs to be updated
+      if (val.indexOf(tagWithStyle) > -1 && tokenVal.length > 1)
+        val = val.replace(tagWithStyle, plainTag);
+    } else {
+      if (val.indexOf(plainTag) > -1 && tokenVal.length > 1)
+        val = val.replace(plainTag, tagWithStyle);
+    }
+    return val;
+  }
+
   createToken(title) {
     console.log("Create a token with title", title);
   }
 
   handleTextInput = (e) => {
     let val = this.formatHTML(e.target.value);
+    let newTokenVal = this.updateAutocomplete();
+    val = this.updateTokenColor(val, newTokenVal);
     this.setState({ html: val });
-    this.updateAutocomplete();
     // Reformat phrase to meet database standards
     // (e.g. braces, double dot, spacing)
     val = val
-      .replace(/<u>/g, "[")
+      .replace(/<u[^>]*>/g, "[")
       .replace(/<\/u>/g, "]")
       .replace(/&nbsp;/g, " ");
     let dotInToken = /(?<!\.)\.(?!\.)[^\.\[\]]*\]/g;

--- a/src/pages/Validator/ValidatorForm.js
+++ b/src/pages/Validator/ValidatorForm.js
@@ -67,7 +67,7 @@ export default function ValidatorForm({ query, onDelete, onSubmit }) {
     <form className="ValidatorForm" onSubmit={(e) => e.preventDefault()}>
       <ValidatorField
         title="Question"
-        value={query.question}
+        value={question}
         onChange={setQuestion}
         queryId={query.id}
         entities={entities}
@@ -75,7 +75,7 @@ export default function ValidatorForm({ query, onDelete, onSubmit }) {
       />
       <ValidatorField
         title="Answer"
-        value={query.answer}
+        value={answer}
         onChange={setAnswer}
         queryId={query.id}
         entities={entities}

--- a/src/pages/Validator/ValidatorForm.js
+++ b/src/pages/Validator/ValidatorForm.js
@@ -2,6 +2,7 @@ import React, { useState, useEffect } from "react";
 import ValidatorField from "./ValidatorField";
 import ValidatorToggle from "./ValidatorToggle";
 import ValidatorSelector from "./ValidatorSelector";
+import TokenCreator from "./TokenCreator";
 import axios from 'axios';
 
 export default function ValidatorForm({ query, onDelete, onSubmit }) {
@@ -11,6 +12,7 @@ export default function ValidatorForm({ query, onDelete, onSubmit }) {
   // This makes the assumption that the fetched phrases are valid
   let [questionValid, setQuestionValid] = useState(true);
   let [answerValid, setAnswerValid] = useState(true);
+  let [creatingToken, setCreatingToken] = useState(false);
   let [isAnswerable, setAnswerable] = useState(
     query.isAnswerable ? "Yes" : "No"
   );
@@ -38,6 +40,11 @@ export default function ValidatorForm({ query, onDelete, onSubmit }) {
   };
   useEffect(updateQueryState, [query]);
 
+  /**Creates a token to be added to the server */
+  let createToken = () => {
+    setCreatingToken(true)
+  }
+  
   /**Uploads query payload when the updated query is valid */
   let uploadValidatedQuery = () => {
     let shouldSubmit = [question, answer, isAnswerable, questionType].every(
@@ -72,6 +79,7 @@ export default function ValidatorForm({ query, onDelete, onSubmit }) {
         queryId={query.id}
         entities={entities}
         onValidationChange={setQuestionValid}
+        onCreateToken={createToken}
       />
       <ValidatorField
         title="Answer"
@@ -80,6 +88,7 @@ export default function ValidatorForm({ query, onDelete, onSubmit }) {
         queryId={query.id}
         entities={entities}
         onValidationChange={setAnswerValid}
+        onCreateToken={createToken}
       />
       <div className="query-properties">
         <ValidatorToggle
@@ -107,6 +116,7 @@ export default function ValidatorForm({ query, onDelete, onSubmit }) {
           Delete
         </button>
       </div>
+     {creatingToken && <TokenCreator onDismiss={() => setCreatingToken(false)}/>}
     </form>
   );
 }

--- a/src/pages/Validator/ValidatorSelector.js
+++ b/src/pages/Validator/ValidatorSelector.js
@@ -1,4 +1,4 @@
-import React, { Fragment } from "react";
+import React from "react";
 
 export default function ValidatorSelector({
   title,

--- a/src/pages/Validator/ValidatorToggle.js
+++ b/src/pages/Validator/ValidatorToggle.js
@@ -7,7 +7,7 @@ export default function ValidatorToggle({
   onChange,
 }) {
   let optionEls = options.map((option) => (
-    <button className="option" onClick={() => onChange(option)} key={option}>
+    <button className="option" onClick={() => onChange(option)} key={option} style={option === value ? {color:"var(--text)"}: {color: "white"}}>
       {option}
     </button>
   ));


### PR DESCRIPTION
Tokens that contain valid entity and attribute names will remain blue as before, but now tokens that have incomplete/invalid contents will appear orange.

This addresses part of #22, though it lacks the ability to block submission if a token isn't recognized. It also is not set up to check if the user has made a new token under a new entity name (though this hasn't been implemented yet anyways).

#### Example
Valid (hence, blue colored): `[CLUB.advisor]`, `[COURSE]`
Invalid (orange): `[CLUB.adv]`, `[CLUB.]`, `[CL]`

#### Bugs that need fixing
- [x] **TLDR: Prevent the autocomplete list from inconsistently disappearing.** Sometimes, when the user enters a character in a token, the `ValidatorField` renders twice. On the first render, the token color is correct and the autocomplete options show correctly. Hurray! Moments later, however, the field re-renders and the autocomplete list vanishes (though the token remains the correct color) because `tokenVal` becomes an empty string for some reason. We either need to prevent this double rendering, or keep `showAutocomplete` and `tokenVal` the same from the first render to the second.
- [x] (Optional) When a user first opens a token, or types a single letter, the color of the token stays blue. In theory, it should turn orange, but this is a small detail.