### PR TITLE
Prevents deletion of spaces before opening token brace

### DIFF
--- a/src/pages/Validator/Validator.js
+++ b/src/pages/Validator/Validator.js
@@ -9,6 +9,19 @@ import axios from "axios";
 export default function Validator(props) {
   let maxQueryQueueSize = 10;
   let [queries, setQueries] = useState([]);
+  useEffect(() => {
+    setQueries([
+      {
+        question: "What are the prereqs for[COURSE]?",
+        answer: "The prerequisites for[COURSE]are[COURSE..prerequisites].",
+        type: "other",
+        isAnswerable: true,
+        id: "query id",
+        validated: false,
+      }
+    ])
+  }, [])
+  
   let [selectedIndex, setSelectedIndex] = useState(0);
 
   let deleteCurrentQuery = async () => {
@@ -34,17 +47,20 @@ export default function Validator(props) {
 
     // regex to remove anything between HTML entities (potential HTML elements)
     let regex = /&([a-z0-9]+|#[0-9]{1,6}|#x[0-9a-f]{1,6});.*&([a-z0-9]+|#[0-9]{1,6}|#x[0-9a-f]{1,6});/gi;
+    const nonSpacedToken = /((?<=(\w))(?=(\[)))|((?<=(\]))(?=(\w)))/g
 
     // update query in the database
     let data = {
       id: submittedQuery.id,
       isAnswerable: submittedQuery.isAnswerable === "No" ? false : true,
       type: submittedQuery.type,
-      question: submittedQuery.question.replace(regex, ""),
-      answer: submittedQuery.answer.replace(regex, ""),
+      question: submittedQuery.question.replace(regex, "").replace(nonSpacedToken, " "),
+      answer: submittedQuery.answer.replace(regex, "").replace(nonSpacedToken, " "),
       verified: true,
     };
-    let response = await axios.post(`/new_data/update_phrase`, data);
+
+    debugger
+    // let response = await axios.post(`/new_data/update_phrase`, data);
 
     if (updatedQueries.length - 2 <= selectedIndex)
       await fetchMoreQueries(1, updatedQueries);

--- a/src/pages/Validator/Validator.js
+++ b/src/pages/Validator/Validator.js
@@ -9,19 +9,6 @@ import axios from "axios";
 export default function Validator(props) {
   let maxQueryQueueSize = 10;
   let [queries, setQueries] = useState([]);
-  useEffect(() => {
-    setQueries([
-      {
-        question: "What are the prereqs for[COURSE]?",
-        answer: "The prerequisites for[COURSE]are[COURSE..prerequisites].",
-        type: "other",
-        isAnswerable: true,
-        id: "query id",
-        validated: false,
-      }
-    ])
-  }, [])
-  
   let [selectedIndex, setSelectedIndex] = useState(0);
 
   let deleteCurrentQuery = async () => {
@@ -58,9 +45,7 @@ export default function Validator(props) {
       answer: submittedQuery.answer.replace(regex, "").replace(nonSpacedToken, " "),
       verified: true,
     };
-
-    debugger
-    // let response = await axios.post(`/new_data/update_phrase`, data);
+    let response = await axios.post(`/new_data/update_phrase`, data);
 
     if (updatedQueries.length - 2 <= selectedIndex)
       await fetchMoreQueries(1, updatedQueries);

--- a/src/pages/Validator/ValidatorField.js
+++ b/src/pages/Validator/ValidatorField.js
@@ -114,7 +114,7 @@ export default class ValidatorField extends Component {
     val = val
       .replace(/<u>/g, "[")
       .replace(/<\/u>/g, "]")
-      .replace(/&nbsp;/g, "");
+      .replace(/&nbsp;/g, " ");
     let dotInToken = /(?<!\.)\.(?!\.)[^\.\[\]]*\]/g;
     let match = dotInToken.exec(val);
     while (match) {


### PR DESCRIPTION
This fixes an uncaught bug that was deleting non breaking spaces that preceded token names before pushing the validated data to the database.
#### Example: 
previously: `for&nbsp;[CLUB] => for[CLUB]`
now: `for&nbsp;[CLUB] => for [CLUB]`

It also checks for proper spacing after the closing brace (a space won't be inserted before punctuation however).