### PR TITLE
Blocks submission whilst invalid tokens exist

### DIFF
--- a/src/pages/Validator/AutocompleteList.js
+++ b/src/pages/Validator/AutocompleteList.js
@@ -26,7 +26,6 @@ export default function AutocompleteList({
   let handleSelect = (entity) => {
     onSelect(entity);
   };
-
   
   /*
    * Returns a list of synonym autocomplete options, filtered by the input

--- a/src/pages/Validator/Validator.scss
+++ b/src/pages/Validator/Validator.scss
@@ -66,6 +66,11 @@
     }
     .validator-submit-button {
       background: var(--confirm);
+
+      &:disabled {
+        background: gray;
+        opacity: 0.5;
+      }
     }
     .validator-deny-button {
       background: var(--deny);

--- a/src/pages/Validator/Validator.scss
+++ b/src/pages/Validator/Validator.scss
@@ -70,6 +70,7 @@
       &:disabled {
         background: gray;
         opacity: 0.5;
+        cursor: not-allowed;
       }
     }
     .validator-deny-button {

--- a/src/pages/Validator/ValidatorForm.js
+++ b/src/pages/Validator/ValidatorForm.js
@@ -7,6 +7,10 @@ import axios from 'axios';
 export default function ValidatorForm({ query, onDelete, onSubmit }) {
   let [question, setQuestion] = useState(query.question);
   let [answer, setAnswer] = useState(query.answer);
+  // TODO: Passing in 'true' for validity is not entirely safe-
+  // This makes the assumption that the fetched phrases are valid
+  let [questionValid, setQuestionValid] = useState(true);
+  let [answerValid, setAnswerValid] = useState(true);
   let [isAnswerable, setAnswerable] = useState(
     query.isAnswerable ? "Yes" : "No"
   );
@@ -67,6 +71,7 @@ export default function ValidatorForm({ query, onDelete, onSubmit }) {
         onChange={setQuestion}
         queryId={query.id}
         entities={entities}
+        onValidationChange={setQuestionValid}
       />
       <ValidatorField
         title="Answer"
@@ -74,6 +79,7 @@ export default function ValidatorForm({ query, onDelete, onSubmit }) {
         onChange={setAnswer}
         queryId={query.id}
         entities={entities}
+        onValidationChange={setAnswerValid}
       />
       <div className="query-properties">
         <ValidatorToggle
@@ -93,6 +99,7 @@ export default function ValidatorForm({ query, onDelete, onSubmit }) {
         <button
           className="validator-submit-button"
           onClick={uploadValidatedQuery}
+          disabled={!questionValid || !answerValid}
         >
           Submit
         </button>


### PR DESCRIPTION
This uses the same logic as this #32 to detect invalid tokens, but doesn't attempt to colorize the tokens (which is where we are running into problems). If we continue to have problems colorizing the tokens, we can just merge this PR to block the user from submitting (at the very least, this will help maintain the integrity of the database).

#### Testing
I informally tested this by playing around with the validator form, but maybe one of you guys could interact with it too just to make sure there aren't any loopholes in the logic.