### PR TITLE
'Delete query' bug fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   "scripts": {
     "start": "REACT_APP_STAGE=dev react-scripts start",
     "start:prod": "REACT_APP_STAGE=prod react-scripts start",
-    "build": "react-scripts build",
+    "build": "REACT_APP_STAGE=prod react-scripts build",
     "test": "react-scripts test",
     "eject": "react-scripts eject"
   },

--- a/src/pages/Validator/Validator.js
+++ b/src/pages/Validator/Validator.js
@@ -12,7 +12,7 @@ export default function Validator(props) {
 
   let deleteCurrentQuery = async () => {
     let updatedQueries = [...queries];
-    let data = updatedQueries.splice(selectedIndex, 1);
+    let data = updatedQueries.splice(selectedIndex, 1)[0];
 
     // delete query in database
     axios.post(`/new_data/delete_phrase`, data);

--- a/src/pages/Validator/Validator.js
+++ b/src/pages/Validator/Validator.js
@@ -12,10 +12,10 @@ export default function Validator(props) {
 
   let deleteCurrentQuery = async () => {
     let updatedQueries = [...queries];
-    updatedQueries.splice(selectedIndex, 1);
+    let data = updatedQueries.splice(selectedIndex, 1);
 
     // delete query in database
-    axios.post(`/new_data/delete_phrase`);
+    axios.post(`/new_data/delete_phrase`, data);
 
     // If we have fallen below 2 queries remaining, fetch 3 more.
     if (updatedQueries.length < 2) await fetchMoreQueries(3, updatedQueries);

--- a/src/pages/Validator/ValidatorForm.js
+++ b/src/pages/Validator/ValidatorForm.js
@@ -65,8 +65,8 @@ export default function ValidatorForm({ query, onDelete, onSubmit }) {
   let deleteQuery = () => {
     onDelete();
     console.log(
-      "This will delete the currently selected query in server as well:",
-      query.id
+      "This will delete the currently selected query (ID =", query.id, 
+      ") in server as well"
     );
   };
 


### PR DESCRIPTION
The button that deletes the currently selected query wasn't working previously. It turns out we were sending the appropriate data to the API, but it was wrapped in an array and causing issues. Simply sending the query object fixed the issue.