### PR TITLE
Cancel login animations on component destroy

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   "scripts": {
     "start": "REACT_APP_STAGE=dev react-scripts start",
     "start:prod": "REACT_APP_STAGE=prod react-scripts start",
-    "build": "react-scripts build",
+    "build": "REACT_APP_STAGE=prod react-scripts build",
     "test": "react-scripts test",
     "eject": "react-scripts eject"
   },

--- a/src/components/LoginHero/LoginHero.js
+++ b/src/components/LoginHero/LoginHero.js
@@ -4,73 +4,82 @@ import './LoginHero.scss';
 const d = 300;
 
 function randomDist(dist) {
-    return (Math.random() * 2 - 1) * dist
+  return (Math.random() * 2 - 1) * dist
 }
 
 // general purpose function used to delay for a set amount of time
-const sleep = (ms) => new Promise(resolve => {
-    setTimeout(() => {
-        resolve()
-    }, ms)
-})
+const sleep = (ms, timeouts) => new Promise(resolve => {
+  let timer = setTimeout(() => {
+    resolve();
+  }, ms);
+  timeouts.push(timer);
+});
 
 export default function LoginHero() {
-    let messages = ["Hello Nimbus",
-        "Nimbus, consider yourself validated",
-        "Nimbus, what is CSAI?",
-        "Nimbus, take me to your data",
-        "Let's clean some data",
-        "CS + AI = best club ever"];
-    let [index, setIndex] = useState(Math.floor(Math.random() * messages.length));
-    let messageRef = useRef(null);
-    let currentMessage = messages[index].split('').map((char, i) => <span className='letter' style={{
-        display: `${char === ' ' ? 'initial' : ''}`
-    }} key={i} > {char}</ span >);
+  let messages = ["Hello Nimbus",
+    "Nimbus, consider yourself validated",
+    "Nimbus, what is CSAI?",
+    "Nimbus, take me to your data",
+    "Let's clean some data",
+    "CS + AI = best club ever"];
+  let [index, setIndex] = useState(Math.floor(Math.random() * messages.length));
 
-    let animateLetters = () => {
-        
-        let letters = [...messageRef.current.children];
-        const animationDuration = 1000
-        const displayTime = 5000
-        let isOnScreen = true;
-        // NOTE: isOnScreen currently will NOT be set to false when the user changes the screen, which is the opposite of what we want
-        const cleanup = () => {
-            // TODO: Make a cleanup function that stops the memory leak error.
-            letters.forEach(letter => letter.getAnimations().forEach(anim => anim.cancel()));
-            isOnScreen = false
-        }
+  const componentIsMountedRef = useRef(true);
+  let messageRef = useRef(null);
+  let currentMessage = messages[index].split('').map((char, i) => <span className='letter' style={{
+    display: `${char === ' ' ? 'initial' : ''}`
+  }} key={i} > {char}</ span >);
 
-        const letterAnimationState = letters.map(async (letter, i) => {
-            let delay = i * 100;
+  let animateLetters = () => {
+  
+    let letters = [...messageRef.current.children];
+    let timeouts = [];
+    const animationDuration = 1000
+    const displayTime = 5000
 
-            // animate each individual span element (character)
-            let keyframes = {
-                transform: [
-                    `translate(${randomDist(d)}px, ${randomDist(d)}px)`,
-                    'translate(0, 0)'],
-                opacity: ['0.2', '1']
-            };
-            // easing: easInOutBack from https://easings.net/#easeInOutBack
-            let anim = letter.animate(keyframes, { duration: animationDuration, easing: 'cubic-bezier(0.68, -0.6, 0.32, 1.6)', delay: delay, fill: "forwards" });
-            await sleep(animationDuration + displayTime)
-            if(!isOnScreen) return cleanup
-            anim.reverse()
-            await sleep(animationDuration)
-        });
-
-        Promise.all(letterAnimationState).then(() => setIndex(i => (i + 1) % messages.length))
-
-        return cleanup;
+    const cleanup = () => {
+      letters.forEach(letter => letter.getAnimations().forEach(anim => anim.cancel()));
+      timeouts.forEach(timer => clearTimeout(timer));
     }
 
-    useEffect(animateLetters, [messageRef, index]);
+    const letterAnimationState = letters.map(async (letter, i) => {
+      let delay = i * 100;
 
-    return (
-        <div className="LoginHero">
-            <h2 className="title">Nimbus Validator</h2>
-            <p className="message" ref={messageRef}>
-                {currentMessage}
-            </p>
-        </div >
-    );
+      // animate each individual span element (character)
+      let keyframes = {
+          transform: [
+              `translate(${randomDist(d)}px, ${randomDist(d)}px)`,
+              'translate(0, 0)'],
+          opacity: ['0.2', '1']
+      };
+      // easing: easInOutBack from https://easings.net/#easeInOutBack
+      let anim = letter.animate(keyframes, { duration: animationDuration, easing: 'cubic-bezier(0.68, -0.6, 0.32, 1.6)', delay: delay, fill: "forwards" });
+      await sleep(animationDuration + displayTime, timeouts)
+      if(!componentIsMountedRef) return cleanup
+      anim.reverse()
+      await sleep(animationDuration, timeouts)
+    });
+
+    Promise.all(letterAnimationState).then(() => setIndex(i => (i + 1) % messages.length))
+
+    return cleanup;
+  }
+
+  /* Ground truth for when the component is unmounted */
+  useEffect(() => {
+    return () => { 
+      componentIsMountedRef.current = false
+    }
+  }, []);
+  useEffect(animateLetters, [messageRef, index]);
+  
+
+  return (
+    <div className="LoginHero">
+      <h2 className="title">Nimbus Validator</h2>
+      <p className="message" ref={messageRef}>
+        {currentMessage}
+      </p>
+    </div>
+  );
 }

--- a/src/pages/Validator/Validator.js
+++ b/src/pages/Validator/Validator.js
@@ -12,7 +12,7 @@ export default function Validator(props) {
 
   let deleteCurrentQuery = async () => {
     let updatedQueries = [...queries];
-    let data = updatedQueries.splice(selectedIndex, 1);
+    let data = updatedQueries.splice(selectedIndex, 1)[0];
 
     // delete query in database
     axios.post(`/new_data/delete_phrase`, data);

--- a/src/pages/Validator/Validator.js
+++ b/src/pages/Validator/Validator.js
@@ -12,10 +12,10 @@ export default function Validator(props) {
 
   let deleteCurrentQuery = async () => {
     let updatedQueries = [...queries];
-    updatedQueries.splice(selectedIndex, 1);
+    let data = updatedQueries.splice(selectedIndex, 1);
 
     // delete query in database
-    axios.post(`/new_data/delete_phrase`);
+    axios.post(`/new_data/delete_phrase`, data);
 
     // If we have fallen below 2 queries remaining, fetch 3 more.
     if (updatedQueries.length < 2) await fetchMoreQueries(3, updatedQueries);

--- a/src/pages/Validator/ValidatorForm.js
+++ b/src/pages/Validator/ValidatorForm.js
@@ -65,8 +65,8 @@ export default function ValidatorForm({ query, onDelete, onSubmit }) {
   let deleteQuery = () => {
     onDelete();
     console.log(
-      "This will delete the currently selected query in server as well:",
-      query.id
+      "This will delete the currently selected query (ID =", query.id, 
+      ") in server as well"
     );
   };
 


### PR DESCRIPTION
This PR resolves #39 and ends the login animation when the user goes to a different page.

#### What's new
We're collecting the timeout references into an array whenever `setTimeout()` is called, and then cancelling those timeouts with `clearTimeout()` when the component will unmount. We are detecting when the component will unmount using the cleanup function returned in `useEffect`

#### Indentation apologies
My editor changed the indentation of the `loginHero` file from 4 spaces to 2 spaces. This makes it appear as if I changed almost every line in the file, so it will be harder to see which lines I actually altered.